### PR TITLE
feat: 카카오 프로필 이미지 받아오는 로직 추가

### DIFF
--- a/src/main/java/angel_bridge/angel_bridge_server/domain/member/entity/Member.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/member/entity/Member.java
@@ -33,6 +33,9 @@ public class Member extends BaseEntity {
     @Column(length = 320)
     private String email;
 
+    @Column(name = "profile_image")
+    private String profileImage;
+
     @Column(name = "phone_number", length = 20)
     private String phoneNumber;
 
@@ -41,7 +44,7 @@ public class Member extends BaseEntity {
     private LoginType loginType;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 8)
+    @Column(nullable = false, length = 10)
     private MemberStatus status;
 
     @Column
@@ -60,10 +63,11 @@ public class Member extends BaseEntity {
     }
 
     @Builder
-    public Member(String name, String nickname, String email, String phoneNumber, String loginType, String status, String role, String oauthname, LocalDateTime inactiveDate) {
+    public Member(String name, String nickname, String email, String profileImage, String phoneNumber, String loginType, String status, String role, String oauthname, LocalDateTime inactiveDate) {
         this.name = name;
         this.nickname = nickname;
         this.email = email;
+        this.profileImage = profileImage;
         this.phoneNumber = phoneNumber;
         this.loginType = (loginType == null || loginType.isEmpty()) ? LoginType.KAKAO : LoginType.valueOf(loginType);
         this.status = (status == null || status.isEmpty()) ? MemberStatus.ACTIVE : MemberStatus.valueOf(status);

--- a/src/main/java/angel_bridge/angel_bridge_server/global/oauth2/dto/KakaoResponse.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/global/oauth2/dto/KakaoResponse.java
@@ -47,4 +47,22 @@ public class KakaoResponse implements OAuth2Response{
 
         return (String) profile.get("nickname");
     }
+
+    @Override
+    public String getProfileImageUrl() {
+
+        Map<String, Object> account = (Map<String, Object>) attribute.get("kakao_account");
+
+        if (account == null) {
+            return null;
+        }
+
+        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+
+        if (profile == null || profile.get("profile_image_url") == null) {
+            return null;
+        }
+
+        return (String) profile.get("profile_image_url");
+    }
 }

--- a/src/main/java/angel_bridge/angel_bridge_server/global/oauth2/dto/OAuth2Response.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/global/oauth2/dto/OAuth2Response.java
@@ -13,4 +13,6 @@ public interface OAuth2Response {
 
     //사용자 실명 (설정한 이름)
     String getName();
+
+    String getProfileImageUrl();
 }

--- a/src/main/java/angel_bridge/angel_bridge_server/global/oauth2/dto/OAuthUserDTO.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/global/oauth2/dto/OAuthUserDTO.java
@@ -9,6 +9,7 @@ public record OAuthUserDTO (
         Member member,
         String role,
         String nickname,
-        String oauthname
+        String oauthname,
+        String profileImageUrl
 ) {
 }

--- a/src/main/java/angel_bridge/angel_bridge_server/global/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/global/oauth2/service/CustomOAuth2UserService.java
@@ -52,6 +52,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             Member member = Member.builder()
                     .oauthname(oauthname)
                     .nickname(oAuth2Response.getName())
+                    .profileImage(oAuth2Response.getProfileImageUrl())
                     .role("ROLE_USER")
                     .build();
 
@@ -60,6 +61,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             OAuthUserDTO oAuthUserDTO = OAuthUserDTO.builder()
                     .oauthname(oauthname)
                     .nickname(oAuth2Response.getName())
+                    .profileImageUrl(member.getProfileImage())
                     .role("ROLE_USER")
                     .build();
 
@@ -67,13 +69,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         }
         else {
 
-            existData.update(oAuth2Response.getName());
-
-            memberRepository.save(existData);
-
             OAuthUserDTO oAuthUserDTO = OAuthUserDTO.builder()
                     .oauthname(existData.getOauthname())
-                    .nickname(oAuth2Response.getName())
+                    .nickname(existData.getNickname()) // 기존의 nickname 사용
+                    .profileImageUrl(existData.getProfileImage())
                     .role(existData.getRole())
                     .build();
 


### PR DESCRIPTION
## ✨ 연관된 이슈
> close #20 


## 📝 작업 내용
1. Member 엔티티에 `profile_image` 필드 추가
2. 카카오에서 프로필 이미지 url 받아오는 로직 추가


### 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
