### PR TITLE
fix : 이미지 링크를 getImageUrl 로 응답 반환

### DIFF
--- a/src/main/java/angel_bridge/angel_bridge_server/domain/member/dto/response/MemberResponseDto.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/member/dto/response/MemberResponseDto.java
@@ -39,4 +39,19 @@ public record MemberResponseDto(
                 .isRegistered(member.getIsRegistered())
                 .build();
     }
+
+    public static MemberResponseDto from(Member member, String imageUrl) {
+
+        return MemberResponseDto.builder()
+                .memberId(member.getId())
+                .nickname(member.getNickname())
+                .email(member.getEmail())
+                .profileImageUrl(imageUrl != null ? imageUrl : member.getProfileImage())
+                .profileImageType(member.getImageType().getDescription())
+                .phoneNumber(member.getPhoneNumber())
+                .role(member.getRole())
+                .isSelect(member.getIsSelect())
+                .isRegistered(member.getIsRegistered())
+                .build();
+    }
 }

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/member/service/MemberService.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/member/service/MemberService.java
@@ -37,7 +37,7 @@ public class MemberService {
 
         Member member = findMemberById(memberId);
 
-        return MemberResponseDto.from(member);
+        return createMemberResponseDto(member);
     }
 
     // [PUT] 회원 정보 수정
@@ -58,7 +58,23 @@ public class MemberService {
         member.update(request, newImage);
         Member updateMember = memberRepository.save(member);
 
-        return MemberResponseDto.from(updateMember);
+        return createMemberResponseDto(updateMember);
+    }
+
+    /**
+     * 이미지 타입에 따른 MemberResponseDto 생성하는 로직
+     */
+    private MemberResponseDto createMemberResponseDto(Member member) {
+
+        String imageUrl;
+
+        if (member.getImageType().equals(ProfileImageType.KAKAO) || member.getProfileImage() == null) {
+            imageUrl = null;
+        } else {
+            imageUrl = imageService.getImageUrl(member.getProfileImage());
+        }
+
+        return MemberResponseDto.from(member, imageUrl);
     }
 
     /**


### PR DESCRIPTION
## ✨ 연관된 이슈
> close #24 


## 📝 작업 내용
`imageService`의 `getImageUrl` 메소드를 이용해 s3에 저장된 이미지 파일을 링크로 반환하도록 로직을 수정하였습니다.

단, 이미지 파일이 s3에 저장되어 있지 않은 카카오 프로필이나 `null` 의 경우, `member.getProfileImage()` 값을 그대로 반환하도록 설정하였습니다.

### 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
