### PR TITLE
feat : 수강 내역 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 //	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.boot:spring-boot-starter'
 
 	// mysql
 	implementation 'mysql:mysql-connector-java:8.0.33'

--- a/src/main/java/angel_bridge/angel_bridge_server/AngelBridgeServerApplication.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/AngelBridgeServerApplication.java
@@ -1,12 +1,13 @@
 package angel_bridge.angel_bridge_server;
 
-import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class AngelBridgeServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/enrollment/controller/EnrollmentController.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/enrollment/controller/EnrollmentController.java
@@ -1,0 +1,44 @@
+package angel_bridge.angel_bridge_server.domain.enrollment.controller;
+
+import angel_bridge.angel_bridge_server.domain.enrollment.dto.response.EnrollmentResponseDto;
+import angel_bridge.angel_bridge_server.domain.enrollment.service.EnrollmentService;
+import angel_bridge.angel_bridge_server.global.common.response.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/api/v1/enrollment")
+@Tag(name = "USER_Enrollment", description = "USER 프로그램 수강 관련 API")
+public class EnrollmentController {
+
+    private final EnrollmentService enrollmentService;
+
+    @Operation(summary = "수강예정 프로그램 조회", description = "수강 예정인 프로그램 조회하는 API")
+    @GetMapping("/scheduled")
+    public CommonResponse<List<EnrollmentResponseDto>> getScheduledProgram(@RequestParam(defaultValue = "1") int page) {
+
+        return new CommonResponse<>(enrollmentService.getScheduledProgram(page), "수강 예정인 프로그램 조회에 성공하였습니다.");
+    }
+
+    @Operation(summary = "수강중 프로그램 조회", description = "수강 중인 프로그램 조회하는 API")
+    @GetMapping("/inprogress")
+    public CommonResponse<List<EnrollmentResponseDto>> getInProgressProgram(@RequestParam(defaultValue = "1") int page) {
+
+        return new CommonResponse<>(enrollmentService.getInProgressProgram(page), "수강 중인 프로그램 조회에 성공하였습니다.");
+    }
+
+    @Operation(summary = "수강완료 프로그램 조회", description = "수강 완료인 프로그램 조회하는 API")
+    @GetMapping("/completed")
+    public CommonResponse<List<EnrollmentResponseDto>> getCompletedProgram(@RequestParam(defaultValue = "1") int page) {
+
+        return new CommonResponse<>(enrollmentService.getCompletedProgram(page), "수강 완료인 프로그램 조회에 성공하였습니다.");
+    }
+}

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/enrollment/dto/response/EnrollmentResponseDto.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/enrollment/dto/response/EnrollmentResponseDto.java
@@ -1,0 +1,46 @@
+package angel_bridge.angel_bridge_server.domain.enrollment.dto.response;
+
+import angel_bridge.angel_bridge_server.domain.enrollment.entity.Enrollment;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record EnrollmentResponseDto(
+
+        @Schema(description = "프로그램 id", example = "1")
+        Long educationId,
+
+        @Schema(description = "프리뷰 이미지", example = "프리뷰 이미지 url")
+        String preImage,
+
+        @Schema(description = "프로그램 소개", example = "21일 간 9개의 미션 수행 및 피드백")
+        String description,
+
+        @Schema(description = "제목", example = "예비 창업 패키지 2주 완성")
+        String title,
+
+        @Schema(description = "프로그램 시작 날짜", example = "2024-12-16")
+        LocalDate educationStartDate,
+
+        @Schema(description = "프로그램 종료 날짜", example = "2025-01-05")
+        LocalDate educationEndDate,
+
+        @Schema(description = "수강 여부", example = "수강예정 | 수강중 | 수강완료")
+        String enrollmentStatus
+) {
+
+    public static EnrollmentResponseDto from(Enrollment enrollment, String preImage) {
+
+        return EnrollmentResponseDto.builder()
+                .educationId(enrollment.getEducation().getId())
+                .preImage(preImage)
+                .description(enrollment.getEducation().getEducationDescription())
+                .title(enrollment.getEducation().getEducationTitle())
+                .educationStartDate(enrollment.getEducation().getEducationStartDate())
+                .educationEndDate(enrollment.getEducation().getEducationEndDate())
+                .enrollmentStatus(enrollment.getEnrollmentStatus().getDescription())
+                .build();
+    }
+}

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/enrollment/entity/Enrollment.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/enrollment/entity/Enrollment.java
@@ -1,21 +1,22 @@
-package angel_bridge.angel_bridge_server.domain.apply.entity;
+package angel_bridge.angel_bridge_server.domain.enrollment.entity;
 
 import angel_bridge.angel_bridge_server.domain.education.entity.Education;
 import angel_bridge.angel_bridge_server.domain.member.entity.Member;
 import angel_bridge.angel_bridge_server.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Apply extends BaseEntity {
+public class Enrollment extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "apply_id", nullable = false)
+    @Column(name = "enrollment_id", nullable = false)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -25,5 +26,20 @@ public class Apply extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "education_id")
     private Education education;
+
+    @Column(name = "is_paid")
+    private boolean isPaid;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "enrollment_status")
+    private EnrollmentStatus enrollmentStatus;
+
+    @Builder
+    public Enrollment(Member member, Education education, boolean isPaid, EnrollmentStatus enrollmentStatus) {
+        this.member = member;
+        this.education = education;
+        this.isPaid = isPaid;
+        this.enrollmentStatus = enrollmentStatus;
+    }
 
 }

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/enrollment/entity/EnrollmentStatus.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/enrollment/entity/EnrollmentStatus.java
@@ -1,0 +1,19 @@
+package angel_bridge.angel_bridge_server.domain.enrollment.entity;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public enum EnrollmentStatus {
+
+    SCHEDULED("수강예정"),
+    IN_PROGRESS("수강중"),
+    COMPLETED("수강완료");
+
+    private final String description;
+
+    EnrollmentStatus(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/enrollment/service/EnrollmentService.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/enrollment/service/EnrollmentService.java
@@ -1,0 +1,74 @@
+package angel_bridge.angel_bridge_server.domain.enrollment.service;
+
+import angel_bridge.angel_bridge_server.domain.enrollment.dto.response.EnrollmentResponseDto;
+import angel_bridge.angel_bridge_server.domain.enrollment.entity.EnrollmentStatus;
+import angel_bridge.angel_bridge_server.global.exception.ApplicationException;
+import angel_bridge.angel_bridge_server.global.repository.EnrollmentRepository;
+import angel_bridge.angel_bridge_server.global.s3.service.ImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static angel_bridge.angel_bridge_server.global.exception.ExceptionCode.BAD_REQUEST_ERROR;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class EnrollmentService {
+
+    private final EnrollmentRepository enrollmentRepository;
+    private final ImageService imageService;
+
+    // 자정에 enrollment Status 업데이트
+    @Transactional
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void updateEnrollmentStatus() {
+
+        enrollmentRepository.updateEnrollmentStatusToInProgress();
+        enrollmentRepository.updateEnrollmentStatusToCompleted();
+    }
+
+    // [GET] 수강 중인 프로그램 조회
+    public List<EnrollmentResponseDto> getInProgressProgram(int page) {
+
+        if (page == 0)
+            throw new ApplicationException(BAD_REQUEST_ERROR);
+        Pageable pageable = PageRequest.of(page - 1, 4);
+
+        return enrollmentRepository.findByEnrollmentStatusAndDeletedAtIsNull(EnrollmentStatus.IN_PROGRESS, pageable)
+                .map(enrollment -> EnrollmentResponseDto.from(
+                        enrollment, imageService.getImageUrl(enrollment.getEducation().getEducationPreImage())))
+                .stream().toList();
+    }
+
+    // [GET] 수강 예정인 프로그램 조회
+    public List<EnrollmentResponseDto> getScheduledProgram(int page) {
+
+        if (page == 0)
+            throw new ApplicationException(BAD_REQUEST_ERROR);
+        Pageable pageable = PageRequest.of(page - 1, 4);
+
+        return enrollmentRepository.findByEnrollmentStatusAndDeletedAtIsNull(EnrollmentStatus.SCHEDULED, pageable)
+                .map(enrollment -> EnrollmentResponseDto.from(
+                        enrollment, imageService.getImageUrl(enrollment.getEducation().getEducationPreImage())))
+                .stream().toList();
+    }
+
+    // [GET] 수강 완료인 프로그램 조회
+    public List<EnrollmentResponseDto> getCompletedProgram(int page) {
+
+        if (page == 0)
+            throw new ApplicationException(BAD_REQUEST_ERROR);
+        Pageable pageable = PageRequest.of(page - 1, 4);
+
+        return enrollmentRepository.findByEnrollmentStatusAndDeletedAtIsNull(EnrollmentStatus.COMPLETED, pageable)
+                .map(enrollment -> EnrollmentResponseDto.from(
+                        enrollment, imageService.getImageUrl(enrollment.getEducation().getEducationPreImage())))
+                .stream().toList();
+    }
+}

--- a/src/main/java/angel_bridge/angel_bridge_server/global/repository/EnrollmentRepository.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/global/repository/EnrollmentRepository.java
@@ -1,0 +1,25 @@
+package angel_bridge.angel_bridge_server.global.repository;
+
+import angel_bridge.angel_bridge_server.domain.enrollment.entity.Enrollment;
+import angel_bridge.angel_bridge_server.domain.enrollment.entity.EnrollmentStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
+
+    Page<Enrollment> findByEnrollmentStatusAndDeletedAtIsNull(EnrollmentStatus status, Pageable pageable);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE Enrollment e SET e.enrollmentStatus = 'IN_PROGRESS' WHERE e.education.educationStartDate <= CURRENT_DATE AND e.enrollmentStatus = 'SCHEDULED'")
+    void updateEnrollmentStatusToInProgress();
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE Enrollment e SET e.enrollmentStatus = 'COMPLETED' WHERE e.education.educationEndDate <= CURRENT_DATE AND e.enrollmentStatus = 'IN_PROGRESS'")
+    void updateEnrollmentStatusToCompleted();
+}


### PR DESCRIPTION
## ✨ 연관된 이슈
> close #30 


## 📝 작업 내용
- Apply -> Enrollment로 엔티티 이름 변경하였습니다.
- SCHEDULED, IN_PROGRESS, COMPLETED 로 수강 상태 enum 추가 + enrollment 필드에도 추가
- 수강 중인 프로그램 조회 api 구현 (`api/v1/enrollment/inprogress?page={}`)
- 수강 예정인 프로그램 조회 api 구현 (`api/v1/enrollment/scheduled?page={}`)
- 수강 완료인 프로그램 조회 api 구현 (`api/v1/enrollment/completed?page={}`)
- 자정에 수강 상태 업데이트 해주는 스케줄링 코드 추가했습니다!!

### 스크린샷 (선택)


## 💬 리뷰 요구사항(선택)
