### PR TITLE
feat: 결제 관련 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,10 @@ dependencies {
 
 	// s3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	// webclient
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'io.projectreactor.netty:reactor-netty:1.0.26'
 }
 
 tasks.named('test') {

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/enrollment/entity/Enrollment.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/enrollment/entity/Enrollment.java
@@ -27,9 +27,6 @@ public class Enrollment extends BaseEntity {
     @JoinColumn(name = "education_id")
     private Education education;
 
-    @Column(name = "is_paid")
-    private boolean isPaid;
-
     @Enumerated(EnumType.STRING)
     @Column(name = "enrollment_status")
     private EnrollmentStatus enrollmentStatus;
@@ -38,7 +35,6 @@ public class Enrollment extends BaseEntity {
     public Enrollment(Member member, Education education, boolean isPaid, EnrollmentStatus enrollmentStatus) {
         this.member = member;
         this.education = education;
-        this.isPaid = isPaid;
         this.enrollmentStatus = enrollmentStatus;
     }
 

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/enrollment/entity/EnrollmentStatus.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/enrollment/entity/EnrollmentStatus.java
@@ -3,6 +3,8 @@ package angel_bridge.angel_bridge_server.domain.enrollment.entity;
 import lombok.Getter;
 import lombok.ToString;
 
+import java.time.LocalDate;
+
 @Getter
 @ToString
 public enum EnrollmentStatus {
@@ -15,5 +17,17 @@ public enum EnrollmentStatus {
 
     EnrollmentStatus(String description) {
         this.description = description;
+    }
+
+    public static EnrollmentStatus getStatusFromEducationStartDate(
+            LocalDate educationStartDate,
+            LocalDate educationEndDate) {
+
+        LocalDate now = LocalDate.now();
+        if (now.isBefore(educationStartDate))
+            return SCHEDULED;
+        if (now.isAfter(educationEndDate))
+            return COMPLETED;
+        return IN_PROGRESS;
     }
 }

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/payment/controller/PaymentController.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/payment/controller/PaymentController.java
@@ -1,7 +1,7 @@
 package angel_bridge.angel_bridge_server.domain.payment.controller;
 
 import angel_bridge.angel_bridge_server.domain.payment.dto.request.ConfirmPaymentRequestDto;
-import angel_bridge.angel_bridge_server.domain.payment.dto.response.CancelReasonResponseDto;
+import angel_bridge.angel_bridge_server.domain.payment.dto.response.CancelPaymentRequestDto;
 import angel_bridge.angel_bridge_server.domain.payment.dto.response.PaymentResponseDto;
 import angel_bridge.angel_bridge_server.domain.payment.service.PaymentService;
 import angel_bridge.angel_bridge_server.global.common.response.CommonResponse;
@@ -34,10 +34,10 @@ public class PaymentController {
     @Operation(summary = "결제 취소", description = "결제 취소 API")
     @PostMapping("/cancel/{enrollmentId}")
     public CommonResponse<Void> confirmPayment(
-            @RequestBody CancelReasonResponseDto cancelReasonResponseDto,
+            @RequestBody CancelPaymentRequestDto cancelPaymentRequestDto,
             @PathVariable Long enrollmentId) throws Exception{
 
-        paymentService.cancelPayment(cancelReasonResponseDto, enrollmentId);
+        paymentService.cancelPayment(cancelPaymentRequestDto, enrollmentId);
         return new CommonResponse<>("결제 취소가 완료되었습니다.");
     }
 

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/payment/controller/PaymentController.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/payment/controller/PaymentController.java
@@ -1,0 +1,31 @@
+package angel_bridge.angel_bridge_server.domain.payment.controller;
+
+import angel_bridge.angel_bridge_server.domain.payment.dto.request.ConfirmPaymentRequestDto;
+import angel_bridge.angel_bridge_server.domain.payment.service.PaymentService;
+import angel_bridge.angel_bridge_server.global.common.response.CommonResponse;
+import angel_bridge.angel_bridge_server.global.oauth2.dto.CustomOAuth2User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AllArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/api/v1/payments")
+@Tag(name = "Toss_Payment", description = "toss 결제 관련 API")
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    @Operation(summary = "결제 승인", description = "결제 승인 API")
+    @PostMapping("/confirm/{educationId}")
+    public CommonResponse<Void> confirmPayment(
+            @RequestBody ConfirmPaymentRequestDto confirmPaymentRequestDto,
+            @PathVariable Long educationId,
+            @AuthenticationPrincipal CustomOAuth2User userDetails) throws Exception{
+
+        paymentService.confirmPayment(confirmPaymentRequestDto, userDetails.getMemberId(), educationId);
+        return new CommonResponse<>("결제 승인이 완료되었습니다.");
+    }
+}

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/payment/controller/PaymentController.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/payment/controller/PaymentController.java
@@ -1,6 +1,7 @@
 package angel_bridge.angel_bridge_server.domain.payment.controller;
 
 import angel_bridge.angel_bridge_server.domain.payment.dto.request.ConfirmPaymentRequestDto;
+import angel_bridge.angel_bridge_server.domain.payment.dto.response.CancelReasonResponseDto;
 import angel_bridge.angel_bridge_server.domain.payment.dto.response.PaymentResponseDto;
 import angel_bridge.angel_bridge_server.domain.payment.service.PaymentService;
 import angel_bridge.angel_bridge_server.global.common.response.CommonResponse;
@@ -28,6 +29,16 @@ public class PaymentController {
 
         paymentService.confirmPayment(confirmPaymentRequestDto, userDetails.getMemberId(), educationId);
         return new CommonResponse<>("결제 승인이 완료되었습니다.");
+    }
+
+    @Operation(summary = "결제 취소", description = "결제 취소 API")
+    @PostMapping("/cancel/{enrollmentId}")
+    public CommonResponse<Void> confirmPayment(
+            @RequestBody CancelReasonResponseDto cancelReasonResponseDto,
+            @PathVariable Long enrollmentId) throws Exception{
+
+        paymentService.cancelPayment(cancelReasonResponseDto, enrollmentId);
+        return new CommonResponse<>("결제 취소가 완료되었습니다.");
     }
 
     @Operation(summary = "결제 내역 조회", description = "결제 내역 조회 API")

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/payment/controller/PaymentController.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/payment/controller/PaymentController.java
@@ -1,6 +1,7 @@
 package angel_bridge.angel_bridge_server.domain.payment.controller;
 
 import angel_bridge.angel_bridge_server.domain.payment.dto.request.ConfirmPaymentRequestDto;
+import angel_bridge.angel_bridge_server.domain.payment.dto.response.PaymentResponseDto;
 import angel_bridge.angel_bridge_server.domain.payment.service.PaymentService;
 import angel_bridge.angel_bridge_server.global.common.response.CommonResponse;
 import angel_bridge.angel_bridge_server.global.oauth2.dto.CustomOAuth2User;
@@ -27,5 +28,12 @@ public class PaymentController {
 
         paymentService.confirmPayment(confirmPaymentRequestDto, userDetails.getMemberId(), educationId);
         return new CommonResponse<>("결제 승인이 완료되었습니다.");
+    }
+
+    @Operation(summary = "결제 내역 조회", description = "결제 내역 조회 API")
+    @GetMapping
+    public CommonResponse<PaymentResponseDto> getPaymentHistory(@AuthenticationPrincipal CustomOAuth2User userDetails) {
+
+        return new CommonResponse<>(paymentService.getPaymentHistory(userDetails.getMemberId()), "결제 내역 조회에 성공하였습니다.");
     }
 }

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/payment/dto/request/ConfirmPaymentRequestDto.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/payment/dto/request/ConfirmPaymentRequestDto.java
@@ -1,0 +1,8 @@
+package angel_bridge.angel_bridge_server.domain.payment.dto.request;
+
+public record ConfirmPaymentRequestDto(
+        String paymentKey,
+        String orderId,
+        Long amount
+) {
+}

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/payment/dto/response/CancelPaymentRequestDto.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/payment/dto/response/CancelPaymentRequestDto.java
@@ -1,0 +1,9 @@
+package angel_bridge.angel_bridge_server.domain.payment.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record CancelPaymentRequestDto(
+        String cancelReason
+) {
+}

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/payment/dto/response/CanceledPaymentResponseDto.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/payment/dto/response/CanceledPaymentResponseDto.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 
 @Builder
 public record CanceledPaymentResponseDto (
+        Long enrollmentId,
         String imageUrl,
         String educationName,
         String price,

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/payment/dto/response/CanceledPaymentResponseDto.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/payment/dto/response/CanceledPaymentResponseDto.java
@@ -1,0 +1,14 @@
+package angel_bridge.angel_bridge_server.domain.payment.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record CanceledPaymentResponseDto (
+        String imageUrl,
+        String educationName,
+        String price,
+        LocalDateTime canceledAt
+){
+}

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/payment/dto/response/CompletePaymentResponseDto.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/payment/dto/response/CompletePaymentResponseDto.java
@@ -7,6 +7,7 @@ import java.time.OffsetDateTime;
 
 @Builder
 public record CompletePaymentResponseDto(
+        Long enrollmentId,
         String imageUrl,
         String educationName,
         String price,

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/payment/dto/response/CompletePaymentResponseDto.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/payment/dto/response/CompletePaymentResponseDto.java
@@ -1,0 +1,15 @@
+package angel_bridge.angel_bridge_server.domain.payment.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+
+@Builder
+public record CompletePaymentResponseDto(
+        String imageUrl,
+        String educationName,
+        String price,
+        LocalDateTime approvedAt
+) {
+}

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/payment/dto/response/ConfirmPaymentResponseDto.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/payment/dto/response/ConfirmPaymentResponseDto.java
@@ -1,0 +1,37 @@
+package angel_bridge.angel_bridge_server.domain.payment.dto.response;
+
+import angel_bridge.angel_bridge_server.domain.payment.entity.PaymentMethod;
+import angel_bridge.angel_bridge_server.domain.payment.entity.PaymentStatus;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ConfirmPaymentResponseDto(
+        @JsonProperty("paymentKey") String paymentKey,
+        @JsonProperty("orderId") String orderId,
+        @JsonProperty("totalAmount") Long totalAmount,
+        @JsonProperty("requestedAt") String requestedAt,
+        @JsonProperty("approvedAt") String approvedAt,
+        @JsonProperty("method") String method,
+        @JsonProperty("status") String status
+) {
+
+    public OffsetDateTime getRequestedAt() {
+        return OffsetDateTime.parse(requestedAt);
+    }
+
+    public OffsetDateTime getApprovedAt() {
+        return OffsetDateTime.parse(approvedAt);
+    }
+
+    public PaymentMethod getPaymentMethod() {
+        return PaymentMethod.fromDescription(method);
+    }
+
+    public PaymentStatus getPaymentStatus() {
+        return PaymentStatus.valueOf(status.toUpperCase());
+    }
+}

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/payment/dto/response/PaymentResponseDto.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/payment/dto/response/PaymentResponseDto.java
@@ -1,0 +1,11 @@
+package angel_bridge.angel_bridge_server.domain.payment.dto.response;
+
+import lombok.Builder;
+import java.util.List;
+
+@Builder
+public record PaymentResponseDto(
+        List<CompletePaymentResponseDto> complete,
+        List<CanceledPaymentResponseDto> canceled
+) {
+}

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/payment/entity/PaymentMethod.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/payment/entity/PaymentMethod.java
@@ -1,0 +1,24 @@
+package angel_bridge.angel_bridge_server.domain.payment.entity;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public enum PaymentMethod {
+
+    VIRTUAL_ACCOUNT("가상계좌"),
+    SIMPLE_PAYMENT("간편결제"),
+    GAME_CULTURE_GIFT_CARD("게임문화상품권"),
+    BANK_TRANSFER("계좌이체"),
+    BOOK_CULTURE_GIFT_CARD("도서문화상품권"),
+    CULTURE_GIFT_CARD("문화상품권"),
+    CREDIT_CARD("카드"),
+    MOBILE_PAYMENT("휴대폰");
+
+    private final String description;
+
+    PaymentMethod(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/payment/entity/PaymentMethod.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/payment/entity/PaymentMethod.java
@@ -1,7 +1,10 @@
 package angel_bridge.angel_bridge_server.domain.payment.entity;
 
+import angel_bridge.angel_bridge_server.global.exception.ApplicationException;
 import lombok.Getter;
 import lombok.ToString;
+
+import static angel_bridge.angel_bridge_server.global.exception.ExceptionCode.NOT_FOUND_PAYMENT_METHOD;
 
 @Getter
 @ToString
@@ -20,5 +23,13 @@ public enum PaymentMethod {
 
     PaymentMethod(String description) {
         this.description = description;
+    }
+
+    public static PaymentMethod fromDescription(String description) {
+        for (PaymentMethod method : PaymentMethod.values()) {
+            if (method.getDescription().equals(description))
+                return method;
+        }
+        throw new ApplicationException(NOT_FOUND_PAYMENT_METHOD);
     }
 }

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/payment/entity/PaymentStatus.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/payment/entity/PaymentStatus.java
@@ -1,0 +1,24 @@
+package angel_bridge.angel_bridge_server.domain.payment.entity;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public enum PaymentStatus {
+
+    ABORTED("중단됨"),
+    CANCELED("취소됨"),
+    DONE("완료됨"),
+    EXPIRED("만료됨"),
+    IN_PROGRESS("진행 중"),
+    PARTIAL_CANCELED("부분 취소됨"),
+    READY("준비됨"),
+    WAITING_FOR_DEPOSIT("입금 대기 중");
+
+    private final String description;
+
+    PaymentStatus(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/payment/entity/TossPayment.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/payment/entity/TossPayment.java
@@ -7,12 +7,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
 
 import java.time.OffsetDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE TossPayment SET deleted_at = NOW() where payment_id = ?")
 public class TossPayment extends BaseEntity {
 
     @Id

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/payment/entity/TossPayment.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/payment/entity/TossPayment.java
@@ -1,0 +1,70 @@
+package angel_bridge.angel_bridge_server.domain.payment.entity;
+
+import angel_bridge.angel_bridge_server.domain.enrollment.entity.Enrollment;
+import angel_bridge.angel_bridge_server.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TossPayment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "payment_id", nullable = false)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "enrollment_id")
+    private Enrollment enrollment;
+
+    @Column(name = "toss_order_id")
+    private String tossOrderId;
+
+    @Column(name = "toss_payment_key", nullable = false, unique = true)
+    private String tossPaymentKey;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "toss_payment_method")
+    private PaymentMethod tossPaymentMethod;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "toss_payment_status")
+    private PaymentStatus tossPaymentStatus;
+
+    @Column(name = "total_amount")
+    private BigDecimal totalAmount;
+
+    @Column(name = "request_at")
+    private LocalDateTime requestAt;
+
+    @Column(name = "approved_at")
+    private LocalDateTime approvedAt;
+
+    @Builder
+    public TossPayment(Enrollment enrollment,
+                       String tossOrderId,
+                       String tossPaymentKey,
+                       PaymentMethod tossPaymentMethod,
+                       PaymentStatus tossPaymentStatus,
+                       BigDecimal totalAmount,
+                       LocalDateTime requestAt,
+                       LocalDateTime approvedAt) {
+
+        this.enrollment = enrollment;
+        this.tossOrderId = tossOrderId;
+        this.tossPaymentKey = tossPaymentKey;
+        this.tossPaymentMethod = tossPaymentMethod;
+        this.tossPaymentStatus = tossPaymentStatus;
+        this.totalAmount = totalAmount;
+        this.requestAt = requestAt;
+        this.approvedAt = approvedAt;
+    }
+}

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/payment/entity/TossPayment.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/payment/entity/TossPayment.java
@@ -25,7 +25,7 @@ public class TossPayment extends BaseEntity {
     @JoinColumn(name = "enrollment_id")
     private Enrollment enrollment;
 
-    @Column(name = "toss_order_id")
+    @Column(name = "toss_order_id", nullable = false)
     private String tossOrderId;
 
     @Column(name = "toss_payment_key", nullable = false, unique = true)

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/payment/entity/TossPayment.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/payment/entity/TossPayment.java
@@ -8,8 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 
 @Entity
 @Getter
@@ -40,13 +39,13 @@ public class TossPayment extends BaseEntity {
     private PaymentStatus tossPaymentStatus;
 
     @Column(name = "total_amount")
-    private BigDecimal totalAmount;
+    private Long totalAmount;
 
     @Column(name = "request_at")
-    private LocalDateTime requestAt;
+    private OffsetDateTime requestAt;
 
     @Column(name = "approved_at")
-    private LocalDateTime approvedAt;
+    private OffsetDateTime approvedAt;
 
     @Builder
     public TossPayment(Enrollment enrollment,
@@ -54,9 +53,9 @@ public class TossPayment extends BaseEntity {
                        String tossPaymentKey,
                        PaymentMethod tossPaymentMethod,
                        PaymentStatus tossPaymentStatus,
-                       BigDecimal totalAmount,
-                       LocalDateTime requestAt,
-                       LocalDateTime approvedAt) {
+                       Long totalAmount,
+                       OffsetDateTime requestAt,
+                       OffsetDateTime approvedAt) {
 
         this.enrollment = enrollment;
         this.tossOrderId = tossOrderId;

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/payment/service/PaymentService.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/payment/service/PaymentService.java
@@ -71,6 +71,7 @@ public class PaymentService {
 
         if (data != null) {
             // 결제 취소 로직 -> enrollment 삭제
+            tossPaymentRepository.delete(payment);
             enrollmentRepository.delete(enrollment);
         } else {
             throw new ApplicationException(PAYMENT_API_FAIL);

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/payment/service/PaymentService.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/payment/service/PaymentService.java
@@ -6,7 +6,6 @@ import angel_bridge.angel_bridge_server.domain.enrollment.entity.EnrollmentStatu
 import angel_bridge.angel_bridge_server.domain.member.entity.Member;
 import angel_bridge.angel_bridge_server.domain.payment.dto.request.ConfirmPaymentRequestDto;
 import angel_bridge.angel_bridge_server.domain.payment.dto.response.ConfirmPaymentResponseDto;
-import angel_bridge.angel_bridge_server.domain.payment.entity.PaymentMethod;
 import angel_bridge.angel_bridge_server.domain.payment.entity.TossPayment;
 import angel_bridge.angel_bridge_server.global.exception.ApplicationException;
 import angel_bridge.angel_bridge_server.global.repository.EducationRepository;
@@ -78,6 +77,7 @@ public class PaymentService {
         Enrollment enrollment = Enrollment.builder()
                 .member(member)
                 .education(education)
+                .isPaid(true)
                 .enrollmentStatus(
                         EnrollmentStatus.getStatusFromEducationStartDate(
                                 education.getEducationStartDate(),

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/payment/service/PaymentService.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/payment/service/PaymentService.java
@@ -47,7 +47,7 @@ public class PaymentService {
 
     // [POST] 결제 취소
     @Transactional
-    public void cancelPayment(CancelReasonResponseDto cancelReasonResponseDto, Long enrollmentId) throws Exception {
+    public void cancelPayment(CancelPaymentRequestDto cancelPaymentRequestDto, Long enrollmentId) throws Exception {
 
         // Enrollment 조회
         Enrollment enrollment = enrollmentRepository.findById(enrollmentId)
@@ -61,7 +61,7 @@ public class PaymentService {
                 .uri(uriBuilder -> uriBuilder
                         .path("/{paymentKey}/cancel")
                         .build(paymentKey))
-                .bodyValue(cancelReasonResponseDto)
+                .bodyValue(cancelPaymentRequestDto)
                 .retrieve()
                 .onStatus(status -> status.value() != 200, clientResponse -> {
                     return Mono.error(new ApplicationException(PAYMENT_API_FAIL));

--- a/src/main/java/angel_bridge/angel_bridge_server/domain/payment/service/PaymentService.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/domain/payment/service/PaymentService.java
@@ -1,0 +1,101 @@
+package angel_bridge.angel_bridge_server.domain.payment.service;
+
+import angel_bridge.angel_bridge_server.domain.education.entity.Education;
+import angel_bridge.angel_bridge_server.domain.enrollment.entity.Enrollment;
+import angel_bridge.angel_bridge_server.domain.enrollment.entity.EnrollmentStatus;
+import angel_bridge.angel_bridge_server.domain.member.entity.Member;
+import angel_bridge.angel_bridge_server.domain.payment.dto.request.ConfirmPaymentRequestDto;
+import angel_bridge.angel_bridge_server.domain.payment.dto.response.ConfirmPaymentResponseDto;
+import angel_bridge.angel_bridge_server.domain.payment.entity.PaymentMethod;
+import angel_bridge.angel_bridge_server.domain.payment.entity.TossPayment;
+import angel_bridge.angel_bridge_server.global.exception.ApplicationException;
+import angel_bridge.angel_bridge_server.global.repository.EducationRepository;
+import angel_bridge.angel_bridge_server.global.repository.EnrollmentRepository;
+import angel_bridge.angel_bridge_server.global.repository.MemberRepository;
+import angel_bridge.angel_bridge_server.global.repository.TossPaymentRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import static angel_bridge.angel_bridge_server.global.exception.ExceptionCode.*;
+
+@Service
+public class PaymentService {
+
+    private final WebClient webClient;
+    private final EnrollmentRepository enrollmentRepository;
+    private final MemberRepository memberRepository;
+    private final EducationRepository educationRepository;
+    private final TossPaymentRepository tossPaymentRepository;
+
+    @Autowired
+    public PaymentService(WebClient.Builder webClientBuilder,
+                          EnrollmentRepository enrollmentRepository,
+                          MemberRepository memberRepository,
+                          EducationRepository educationRepository,
+                          TossPaymentRepository tossPaymentRepository) {
+        this.webClient = webClientBuilder.build();
+        this.enrollmentRepository = enrollmentRepository;
+        this.memberRepository = memberRepository;
+        this.educationRepository = educationRepository;
+        this.tossPaymentRepository = tossPaymentRepository;
+    }
+
+    // 결제 승인
+    @Transactional
+    public void confirmPayment(ConfirmPaymentRequestDto confirmPaymentRequestDto, Long memberId, Long educationId) throws Exception {
+
+        String data = webClient.post()
+                .uri("/confirm")
+                .bodyValue(confirmPaymentRequestDto)
+                .retrieve()
+                .onStatus(status -> status.value() != 200, clientResponse -> {
+                    return Mono.error(new ApplicationException(PAYMENT_API_FAIL));
+                })
+                .bodyToMono(String.class)
+                .block();
+
+        if (data != null) {
+            ObjectMapper objectMapper = new ObjectMapper();
+            ConfirmPaymentResponseDto response = objectMapper.readValue(data, ConfirmPaymentResponseDto.class);
+            savePayment(response, memberId, educationId);
+        } else {
+            throw new ApplicationException(PAYMENT_API_FAIL);
+        }
+    }
+
+    @Transactional
+    public void savePayment(ConfirmPaymentResponseDto response, Long memberId, Long educationId) {
+
+        // enrollment 생성
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ApplicationException(NOT_FOUND_USER));
+        Education education = educationRepository.findById(educationId)
+                .orElseThrow(() -> new ApplicationException(NOT_FOUND_EDUCATION_ID));
+        Enrollment enrollment = Enrollment.builder()
+                .member(member)
+                .education(education)
+                .enrollmentStatus(
+                        EnrollmentStatus.getStatusFromEducationStartDate(
+                                education.getEducationStartDate(),
+                                education.getEducationEndDate()))
+                .build();
+        enrollmentRepository.save(enrollment);
+
+        // payment 생성
+        TossPayment tossPayment = TossPayment.builder()
+                .enrollment(enrollment)
+                .tossOrderId(response.orderId())
+                .tossPaymentKey(response.paymentKey())
+                .tossPaymentMethod(response.getPaymentMethod())
+                .tossPaymentStatus(response.getPaymentStatus())
+                .totalAmount(response.totalAmount())
+                .requestAt(response.getRequestedAt())
+                .approvedAt(response.getApprovedAt())
+                .build();
+        tossPaymentRepository.save(tossPayment);
+    }
+}

--- a/src/main/java/angel_bridge/angel_bridge_server/global/config/WebClientConfig.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/global/config/WebClientConfig.java
@@ -1,0 +1,38 @@
+package angel_bridge.angel_bridge_server.global.config;
+
+import io.netty.channel.ChannelOption;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.time.Duration;
+import java.util.Base64;
+
+@Configuration
+public class WebClientConfig {
+
+    @Value("${payment.secret-key}")
+    private String apiKey;
+
+    @Value("${payment.base-url}")
+    private String baseUrl;
+
+    @Bean
+    public WebClient.Builder webClientBuilder() {
+
+        return WebClient.builder()
+                .baseUrl(baseUrl)
+                .defaultHeader(HttpHeaders.AUTHORIZATION,
+                        "Basic " + Base64.getEncoder().encodeToString((apiKey + ":").getBytes()))
+                .defaultHeader("Content-Type", "application/json")
+                .clientConnector(new ReactorClientHttpConnector(
+                        HttpClient.create()
+                                .responseTimeout(Duration.ofSeconds(5))
+                                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 5000)
+                ));
+    }
+}

--- a/src/main/java/angel_bridge/angel_bridge_server/global/exception/ExceptionCode.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/global/exception/ExceptionCode.java
@@ -45,10 +45,13 @@ public enum ExceptionCode {
     NOT_FOUND_BLOG_ID(HttpStatus.NOT_FOUND, 5001,"존재하지 않는 Blog 입니다."),
     IMAGE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5002, "이미지 저장에 실패하였습니다."),
     NOT_FOUND_EDUCATION_ID(HttpStatus.NOT_FOUND, 5003,"존재하지 않는 교육 프로그램입니다."),
-    NOT_FOUND_BANNER_ID(HttpStatus.NOT_FOUND, 5004,"존재하지 않는 배너입니다.");
+    NOT_FOUND_BANNER_ID(HttpStatus.NOT_FOUND, 5004,"존재하지 않는 배너입니다."),
 
 
-    // 6000: [임의] Error
+    // 6000: payment Error
+    PAYMENT_API_FAIL(HttpStatus.BAD_REQUEST, 6001, "결제 api 호출에 실패하였습니다."),
+    NOT_FOUND_PAYMENT_METHOD(HttpStatus.NOT_FOUND, 6002, "결제 방법이 유효하지 않습니다."),
+    NOT_FOUND_PAYMENT_STATUS(HttpStatus.NOT_FOUND, 6003, "결제 상태가 유효하지 않습니다.");
 
 
     //7000: [임의] Error

--- a/src/main/java/angel_bridge/angel_bridge_server/global/repository/EnrollmentRepository.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/global/repository/EnrollmentRepository.java
@@ -2,12 +2,15 @@ package angel_bridge.angel_bridge_server.global.repository;
 
 import angel_bridge.angel_bridge_server.domain.enrollment.entity.Enrollment;
 import angel_bridge.angel_bridge_server.domain.enrollment.entity.EnrollmentStatus;
+import angel_bridge.angel_bridge_server.domain.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
 
@@ -22,4 +25,7 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
     @Transactional
     @Query("UPDATE Enrollment e SET e.enrollmentStatus = 'COMPLETED' WHERE e.education.educationEndDate <= CURRENT_DATE AND e.enrollmentStatus = 'IN_PROGRESS'")
     void updateEnrollmentStatusToCompleted();
+
+    List<Enrollment> findByMemberAndDeletedAtIsNull(Member member);
+    List<Enrollment> findByMemberAndDeletedAtIsNotNull(Member member);
 }

--- a/src/main/java/angel_bridge/angel_bridge_server/global/repository/TossPaymentRepository.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/global/repository/TossPaymentRepository.java
@@ -1,7 +1,12 @@
 package angel_bridge.angel_bridge_server.global.repository;
 
+import angel_bridge.angel_bridge_server.domain.enrollment.entity.Enrollment;
 import angel_bridge.angel_bridge_server.domain.payment.entity.TossPayment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TossPaymentRepository extends JpaRepository<TossPayment, Long> {
+
+    TossPayment findByEnrollment(Enrollment enrollment);
 }

--- a/src/main/java/angel_bridge/angel_bridge_server/global/repository/TossPaymentRepository.java
+++ b/src/main/java/angel_bridge/angel_bridge_server/global/repository/TossPaymentRepository.java
@@ -1,0 +1,7 @@
+package angel_bridge.angel_bridge_server.global.repository;
+
+import angel_bridge.angel_bridge_server.domain.payment.entity.TossPayment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TossPaymentRepository extends JpaRepository<TossPayment, Long> {
+}


### PR DESCRIPTION
## ✨ 연관된 이슈
> close #32 


## 📝 작업 내용
1. 결제 승인 api (`api/v1/payments/confirm`)
2. 결제 취소 api (`api/v1/payments/cancel/{enrollmentId}`)
3. 결제 내역 조회 api (`api/v1/payments`)


### 스크린샷 (선택)
<img width="833" alt="스크린샷 2025-01-08 오후 2 11 31" src="https://github.com/user-attachments/assets/a7ae806b-6f68-44fe-a7ee-fb3d72406615" />
<img width="455" alt="스크린샷 2025-01-07 오후 4 29 50" src="https://github.com/user-attachments/assets/69b541cf-00b8-4a8f-9fe2-a3b0333ef4aa" />

- 결제  완료하면 위와 같은 화면으로 리다이렉트 됩니다

<img width="831" alt="스크린샷 2025-01-08 오전 2 00 49" src="https://github.com/user-attachments/assets/59c08be4-4b5a-469c-9fa3-de0bc8fb7f3d" />
<img width="1162" alt="스크린샷 2025-01-08 오전 2 01 19" src="https://github.com/user-attachments/assets/978ee2f9-8916-43ba-a079-24a34a8b119e" />

- DB에 수강내역하고 payment가 잘 생성됩니다



## 💬 리뷰 요구사항(선택)
- 현재 프론트 구현이 안되어 있어서 토스에서 제공해주는 테스트 프론트 코드를 통해 동작 확인한 상태입니다.!!
- 다만...결제 취소 프론트 코드는 찾지 못해서 프론트쪽에서 구현 완료 해주어야 '결제 취소' 제대로 동작 확인 가능할거 같습니다!!
